### PR TITLE
Implement ADC authentication via Google credentials; updated dependen…

### DIFF
--- a/droughty/pyproject.toml
+++ b/droughty/pyproject.toml
@@ -9,9 +9,10 @@ repository = 'https://github.com/rittmananalytics/droughty'
 readme = 'README.md'
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = "<3.12,>=3.8"
 GitPython = "3.1.44"
 glom = "23.1.1"
+google-auth = "^2.28.1"
 lkml = "1.3.1"
 Markdown = "3.4.1"
 numpy = "1.24.2"


### PR DESCRIPTION
Implement ADC authentication via Google credentials; updated dependancies to include google-auth. 

- Added get_google_credentials() to handle authentication
- Tries the Google auth first and falls back to service account object or file path if ADC isn’t available
- Updated the dependancy file to include the Google Auth